### PR TITLE
Dry run changes: increase queue pool size & include user names when returning to front end

### DIFF
--- a/backend/DBConnect.py
+++ b/backend/DBConnect.py
@@ -11,7 +11,7 @@ if os.path.exists(env):
     load_dotenv(env)
 
 def get_connection():
-    return create_engine(url=os.environ.get('DB_URL'), pool_size=20, max_overflow=0)
+    return create_engine(url=os.environ.get('DB_URL'), pool_size=100, max_overflow=0)
 
 def session_factory():
     Base.metadata.create_all(engine)


### PR DESCRIPTION
2 changes:
1. Increase queue pool size to 100
2. under filemanage.py .. made changes to return username instead of userid to front end.